### PR TITLE
fix ios safe area and font

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,3 +70,7 @@ strip = true
 tauri-plugin-barcode-scanner = "2"
 tauri-plugin-biometric = "2"
 tauri-plugin-keystore = "2.1.0-alpha.1"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+tauri-plugin-safe-area-insets-css = "0.2"
+tauri-plugin-ios-webview-insets = "0.1"

--- a/src-tauri/capabilities/ios.json
+++ b/src-tauri/capabilities/ios.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "ios-safe-area",
+  "description": "Allow the iOS frontend to read native safe-area insets",
+  "windows": ["main"],
+  "platforms": ["iOS"],
+  "permissions": ["safe-area-insets-css:default"]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,11 @@ pub fn run() {
         .plugin(tauri_plugin_biometric::init())
         .plugin(tauri_plugin_barcode_scanner::init());
 
+    #[cfg(target_os = "ios")]
+    let builder = builder
+        .plugin(tauri_plugin_safe_area_insets_css::init())
+        .plugin(tauri_plugin_ios_webview_insets::init());
+
     #[cfg(any(target_os = "android"))]
     let builder = builder.plugin(tauri_plugin_android_fs::init());
 

--- a/src/app.html
+++ b/src/app.html
@@ -11,7 +11,7 @@
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
-    <div style="display: contents">%sveltekit.body%</div>
+    <div id="app">%sveltekit.body%</div>
     <div class="debug-a"></div>
     <div class="debug-b"></div>
     <div class="debug-c"></div>
@@ -21,8 +21,8 @@
   <style>
     @font-face {
       font-family: "Inter Medium";
-      src: url("/public/fonts/Inter_18pt-Medium.ttf") format("ttf");
-      font-weight: 600;
+      src: url("/fonts/Inter_18pt-Medium.ttf") format("truetype");
+      font-weight: 500;
       font-style: normal;
     }
 
@@ -90,6 +90,7 @@
       overflow: hidden;
       padding-top: env(safe-area-inset-top, 10px);
       padding-bottom: env(safe-area-inset-bottom, 20px);
+      font-family: "Inter Medium", system-ui, sans-serif;
     }
 
     html,
@@ -101,6 +102,46 @@
 
     html {
       scroll-behavior: auto !important;
+    }
+
+    #app {
+      display: contents;
+    }
+
+    html.ios-safe-area #app {
+      display: block;
+      position: fixed;
+      top: var(--safe-area-top, env(safe-area-inset-top, 0px));
+      right: 0;
+      bottom: var(--safe-area-bottom, env(safe-area-inset-bottom, 0px));
+      left: 0;
+      overflow: hidden;
+      transform: translateZ(0);
+    }
+
+    html.ios-safe-area #app > main,
+    html.ios-safe-area #app > main > .container,
+    html.ios-safe-area #app .chat-window {
+      width: 100%;
+      height: 100%;
+    }
+
+    html.ios-safe-area #app .page-card {
+      width: 100%;
+      height: calc(100% - 60px);
+    }
+
+    html.ios-safe-area #app .chat-window,
+    html.ios-safe-area #app .panel {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+
+    button,
+    input,
+    select,
+    textarea {
+      font-family: inherit;
     }
 
     * {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onBackButtonPress } from "@tauri-apps/api/app";
+  import { invoke } from "@tauri-apps/api/core";
   import { onMount, setContext } from "svelte";
   import { fade } from "svelte/transition";
   import { page } from "$app/stores";
@@ -20,13 +21,28 @@
   setContext("onBack", onBack);
 
   onMount(async () => {
+    const system = type();
+
+    if (system === "ios") {
+      try {
+        const [{ inset: top }, { inset: bottom }] = await Promise.all([
+          invoke("plugin:safe-area-insets-css|get_top_inset"),
+          invoke("plugin:safe-area-insets-css|get_bottom_inset"),
+        ]);
+
+        document.documentElement.style.setProperty("--safe-area-top", `${top}px`);
+        document.documentElement.style.setProperty("--safe-area-bottom", `${bottom}px`);
+        document.documentElement.classList.add("ios-safe-area");
+      } catch (error) {
+        console.warn("Native safe-area insets are unavailable", error);
+      }
+    }
+
     settings = await Settings.keys();
 
     /*if (!settings.includes("tokenEncType")) {
       goto("/setup/tokens");
     }*/
-
-    const system = type();
 
     if (system === "android" || system === "ios") {
       await onBackButtonPress((payload) => {


### PR DESCRIPTION
## Summary

- fix iOS safe-area handling around the Dynamic Island and home indicator
- keep safe-area plugins and permissions iOS-only to avoid affecting Android
- use the bundled Inter font across the entire UI
- fix the font asset path, format, and weight declaration

## Testing

- `bun run build`
- `cargo check`
- `IPHONEOS_DEPLOYMENT_TARGET=14.0 cargo check --target aarch64-apple-ios-sim`
- built and tested on iPhone 17 Pro Simulator with iOS 26.5
- verified that iOS-only plugins are absent from the Android dependency graph